### PR TITLE
Fix for undefined "sentence" error caused by PullRequestReviewCommentEvent

### DIFF
--- a/gh-activity.html
+++ b/gh-activity.html
@@ -264,6 +264,7 @@ function callback_events(b) {
     a = a.reverse();
     $.each(a, function (c) {
         var e = "icon-github";
+	sentence = '';
         switch (this.type) {
             case "CommitCommentEvent":
                 verb = "commented on commit";

--- a/gh-activity.html
+++ b/gh-activity.html
@@ -264,7 +264,7 @@ function callback_events(b) {
     a = a.reverse();
     $.each(a, function (c) {
         var e = "icon-github";
-	sentence = '';
+        sentence = '';
         switch (this.type) {
             case "CommitCommentEvent":
                 verb = "commented on commit";


### PR DESCRIPTION
Fixed this fatal error by defining the sentence variable as empty prior to the switch. 